### PR TITLE
Fix overflow when checking EOF

### DIFF
--- a/sql3parse_table.c
+++ b/sql3parse_table.c
@@ -135,7 +135,7 @@ static sql3string temp_identifier = {.ptr = "temp", .length = 4};
 
 // MARK: - Macros -
 
-#define IS_EOF				            (state->offset == state->size)
+#define IS_EOF				            (state->offset >= state->size)
 #define PEEK				            (state->buffer[state->offset])
 #define PEEK2				            (state->buffer[state->offset+1])
 #define NEXT				            (state->buffer[state->offset++])


### PR DESCRIPTION
The fuzzer added in XX finds an overflow fairly fast, with the following stacktrace:


```sh
==13==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000014114 at pc 0x55c3024c35fc bp 0x7fff7b16ca30 sp 0x7fff7b16ca28                                                                                                                                             
READ of size 1 at 0x502000014114 thread T0                                                                                                                                                                                                                                         
SCARINESS: 12 (1-byte-read-heap-buffer-overflow)                                                                                                                                                                                                                                   
    #0 0x55c3024c35fb in sql3lexer_next /src/sqlite-createtable-parser/sql3parse_table.c:435:15                                                                                                                                                                                    
    #1 0x55c3024c0656 in sql3parse /src/sqlite-createtable-parser/sql3parse_table.c:1240:25
    #2 0x55c3024c0656 in sql3parse_table /src/sqlite-createtable-parser/sql3parse_table.c:1546:23
    #3 0x55c3024b5316 in LLVMFuzzerTestOneInput /src/fuzzer.c:24:25      
```

The input to `sqlparse_table` is: "`/**`"

This fixes it by extending `IS_EOF` to also check if the offset has increased beyond the buffer. Can confirm the fuzzer can run now for an extended period of time without findings issues.